### PR TITLE
Add match for sparse constants

### DIFF
--- a/src/riscv_ssa.ml
+++ b/src/riscv_ssa.ml
@@ -250,9 +250,15 @@ let rec sizeof ty =
   | Mtype.T_constr id -> pointer_size
   | Mtype.T_fixedarray _ -> pointer_size
   | Mtype.T_trait _ -> pointer_size
-  (* | Mtype.T_optimized_option { elem } -> pointer_size  *)
+
+  (* Optimized option uses special values to indicate None for integer types *)
+  (* So the size is equal to the underlying integer type *)
+  | Mtype.T_optimized_option { elem } -> sizeof elem
+  
+  (* Same size as the underlying type *)
+  | Mtype.T_maybe_uninit x -> sizeof x
+  
   (* | Mtype.T_any { name } -> pointer_size  *)
-  (* | Mtype.T_maybe_uninit x -> sizeof x *)(*Same size as the contained type *)
   (* | Mtype.T_error_value_result { ok; err; id } -> sizeof ok + sizeof err + pointer_size *)
   | _ -> failwith ("riscv_ssa.ml: cannot calculate size for type: "^ Mtype.to_string ty)
 ;;


### PR DESCRIPTION
Now supports matching for sparse constants (where `max - min > 256`), compiled into a series of if-else.

I chose not to implement a hash function because such sparseness in `match` is quite rare, so we don't need to target it with great effort.

Now the compiler passes test `match03`.