### PR TITLE
Virtual assembly conversion for basic instructions

### DIFF
--- a/src/riscv_reg.ml
+++ b/src/riscv_reg.ml
@@ -170,6 +170,7 @@ Immediate values can either be an integer (`IntImm`) or a floating-point number 
 module Imm = struct
   type t =
     | IntImm of int (* Integer immediate value *)
+    | Int64Imm of int64
     | FloatImm of float (* Floating-point immediate value *)
 
   let to_string imm =

--- a/src/riscv_virtasm.ml
+++ b/src/riscv_virtasm.ml
@@ -43,7 +43,7 @@ module Slots = struct
   type i_slot =
     { rd : Slot.t
     ; rs1 : Slot.t
-    ; imm : Imm.t
+    ; imm : int
     }
 
   (** Defines a single floating-point register assignment with a destination register `frd`. *)
@@ -138,13 +138,13 @@ module Slots = struct
   type mem_slot =
     { rd : Slot.t
     ; base : Slot.t
-    ; offset : Imm.t
+    ; offset : int
     }
 
   type mem_fslot =
     { frd : Slot.t
     ; base : Slot.t
-    ; offset : Imm.t
+    ; offset : int
     }
 
   (**
@@ -172,27 +172,75 @@ module Inst = struct
   type t =
     (* Integer Arithmetic Instructions *)
     | Add of r_slot
+    | Addw of r_slot
+    | Addu of r_slot
+    | Adduw of r_slot
+
     | Sub of r_slot
+    | Subw of r_slot
+    | Subu of r_slot
+    | Subuw of r_slot
+    
+    | Mul of r_slot
+    | Mulw of r_slot
+
+    | Div of r_slot (* signed divide *)
+    | Divw of r_slot
+    | Divu of r_slot (* unsigned divide *)
+    | Divuw of r_slot
+
+    | Rem of r_slot (* signed remainder *)
+    | Remw of r_slot
+    | Remu of r_slot (* unsigned remainder *)
+    | Remuw of r_slot
+
+    | Sextw of assign_slot (* signed extend *)
+    | Zextw of assign_slot (* unsigned extend *)
+
     | Addi of i_slot
+    | Addiw of i_slot
     (* Logical and Shift Instructions *)
     | And of r_slot
     | Or of r_slot
     | Xor of r_slot
+
+    | Andi of i_slot
+    | Ori of i_slot
+    | Xori of i_slot
+
+    | Slt of r_slot (* set less than *)
+    | Sltw of r_slot
+    | Sltu of r_slot
+    | Sltuw of r_slot
+
     | Sll of r_slot (* shift left logical *)
+    | Sllw of r_slot
+
     | Srl of r_slot (* shift right logical *)
+    | Srlw of r_slot
+
     | Sra of r_slot (* shift right arithmetic *)
+    | Sraw of r_slot
+
     | Slli of i_slot (* shift left logical immediate *)
+    | Slliw of i_slot
     | Srli of i_slot (* shift right logical immediate *)
+    | Srliw of i_slot
     | Srai of i_slot (* shift right arithmetic immediate *)
+    | Sraiw of i_slot
+    | Slti of i_slot
+    | Sltiw of i_slot
     (* Multiplication and Division Instructions *)
-    | Mul of r_slot
-    | Div of r_slot (* signed divide *)
-    | Divu of r_slot (* unsigned divide *)
-    | Rem of r_slot (* signed remainder *)
-    | Remu of r_slot (* unsigned remainder *)
     (* Memory Access Instructions *)
+    | Lb of mem_slot
+    | Lbu of mem_slot
+    | Lh of mem_slot
+    | Lhu of mem_slot
     | Lw of mem_slot (* load word 32-bit *)
     | Ld of mem_slot (* load doubleword 64-bit *)
+
+    | Sb of mem_slot
+    | Sh of mem_slot
     | Sw of mem_slot (* store word 32-bit *)
     | Sd of mem_slot (* store doubleword 64-bit *)
     (* Floating-Point Arithmetic Instructions *)

--- a/src/riscv_virtasm_generate.ml
+++ b/src/riscv_virtasm_generate.ml
@@ -1,13 +1,265 @@
 open Riscv_virtasm
 module Ssa = Riscv_ssa
 
-let virtasm_of_ssa (ssa : Ssa.t list) =
-  let vprog : VProg.t =
-    { blocks = VBlockMap.empty
-    ; funcs = VFuncMap.empty
-    ; consts = VSymbolMap.empty
-    ; loop_vars = VBlockMap.empty
-    }
+open Riscv_virtasm
+open Riscv_ssa
+open Riscv_reg
+open Riscv_opt
+
+module Vec = Basic_vec
+
+let slot = ref 0
+let vfuncs: VFunc.t Vec.t = Vec.empty ()
+let vblocks: VBlock.t Vec.t = Vec.empty ()
+let slot_map: (string, Slot.t) Hashtbl.t = Hashtbl.create 2048
+
+(** Phi nodes at the beginning of each block *)
+let phis: (string, Riscv_ssa.phi Vec.t) Hashtbl.t = Hashtbl.create 256
+
+let new_slot () =
+  slot := !slot + 1;
+  !slot
+
+(** Retrieve slot of the variable. When non-existent, create another one. *)
+let slot_v v =
+  if v.name = "_" then
+    Slot.Unit
+  else if Hashtbl.mem slot_map v.name then
+    Hashtbl.find slot_map v.name
+  else (
+    let s = new_slot () in
+    let new_slot =
+      match v.ty with
+      | T_float | T_double -> Slot.FSlot s
+      | _ -> Slot s
+    in
+    Hashtbl.add slot_map v.name new_slot;
+    new_slot
+  )
+
+(** Terminator and body are output arguments *)
+let convert_single name body terminator (inst: Riscv_ssa.t) =
+  let die () = failwith "riscv_virtasm_generate.ml: unsupported" in
+
+  let rslot ({ rd; rs1; rs2 }: Riscv_ssa.r_type) =
+    ({
+      rd = slot_v rd;
+      rs1 = slot_v rs1;
+      rs2 = slot_v rs2
+    }: Slots.r_slot)
   in
-  vprog
-;;
+
+  match inst with
+  | Label l ->
+      (* Don't care about labels. *)
+      (* We're converting for a single basic block, *)
+      (* and labels will be handled outside. *)
+      ()
+
+  | Add ({ rd; rs1; rs2 } as x) ->
+      let r = rslot x in
+      Vec.push body (match rd.ty with
+      | T_int -> Inst.Addw r
+      | T_uint -> Inst.Adduw r
+      | T_int64 -> Inst.Add r
+      | T_uint64 -> Inst.Addu r
+      | _ -> die())
+
+  | Sub ({ rd; rs1; rs2 } as x) ->
+      let r = rslot x in
+      Vec.push body (match rd.ty with
+      | T_int -> Inst.Subw r
+      | T_uint -> Inst.Subuw r
+      | T_int64 -> Inst.Sub r
+      | T_uint64 -> Inst.Subu r
+      | _ -> die())
+
+  | Mul ({ rd; rs1; rs2 } as x) ->
+      let r = rslot x in
+      (match rd.ty with
+      | T_int -> Vec.push body (Inst.Mulw r)
+      | T_uint -> Vec.push body (Inst.Mulw r); Vec.push body (Zextw { rd = r.rd; rs = r.rd })
+      (* As only the last 64-bit is needed, we don't care about signedness *)
+      | T_uint64 | T_int64 -> Vec.push body (Inst.Mul r)
+      | _ -> die())
+
+  | Div ({ rd; rs1; rs2 } as x) ->
+      let r = rslot x in
+      Vec.push body (match rd.ty with
+      | T_int -> Inst.Divw r
+      | T_uint -> Inst.Divuw r
+      | T_int64 -> Inst.Div r
+      | T_uint64 -> Inst.Divu r
+      | _ -> die())
+
+  | Less ({ rd; rs1; rs2 } as x) ->
+      let r = rslot x in
+      Vec.push body (match rd.ty with
+      | T_int | T_int64 -> Inst.Slt r
+      | T_uint | T_uint64 -> Inst.Sltu r
+      | _ -> die())
+
+  | Great { rd; rs1; rs2 } ->
+      (* Note rs1 and rs2 exchanged. *)
+      let r = ({
+        rd = slot_v rd;
+        rs1 = slot_v rs2;
+        rs2 = slot_v rs1;
+      }: Slots.r_slot) in
+
+      Vec.push body (match rd.ty with
+      | T_int | T_int64 -> Inst.Slt r
+      | T_uint | T_uint64 -> Inst.Sltu r
+      | _ -> die())
+
+  | Leq { rd; rs1; rs2 } ->
+      (* rs1 <= rs2, means !(rs2 < rs1) *)
+      
+      let rd_s = slot_v rd in
+      let r = ({
+        rd = rd_s;
+        rs1 = slot_v rs2;
+        rs2 = slot_v rs1;
+      }: Slots.r_slot) in
+
+      Vec.push body (match rd.ty with
+      | T_int | T_int64 -> Inst.Slt r
+      | T_uint | T_uint64 -> Inst.Sltu r
+      | _ -> die());
+
+      (* We negate by xoring 1 *)
+      Vec.push body (Inst.Xori { rd = rd_s; rs1 = rd_s; imm = 1 })
+
+  | Geq { rd; rs1; rs2 } ->
+      (* rs1 >= rs2, means !(rs1 < rs2) *)
+      
+      let r = ({
+        rd = slot_v rd;
+        rs1 = slot_v rs1;
+        rs2 = slot_v rs2;
+      }: Slots.r_slot) in
+
+      Vec.push body (match rd.ty with
+      | T_int | T_int64 -> Inst.Slt r
+      | T_uint | T_uint64 -> Inst.Sltu r
+      | _ -> die());
+
+      (* We negate by xoring 1 *)
+      Vec.push body (Inst.Xori { rd = slot_v rd; rs1 = slot_v rd; imm = 1 })
+
+  | Eq { rd; rs1; rs2 } ->
+      Vec.push body (Inst.Xor { rd = slot_v rd; rs1 = slot_v rs1; rs2 = slot_v rs2 });
+      Vec.push body (Inst.Slti { rd = slot_v rd; rs1 = slot_v rd; imm = 1 })
+
+  | Neq { rd; rs1; rs2 } ->
+      Vec.push body (Inst.Xor { rd = slot_v rd; rs1 = slot_v rs1; rs2 = slot_v rs2 });
+      Vec.push body (Inst.Sltu { rd = slot_v rd; rs1 = Slot.Reg Zero; rs2 = slot_v rd })
+
+  | Call { rd; fn; args }
+  | CallExtern { rd; fn; args } ->
+      let r = slot_v rd in
+      let int_args = Vec.empty () in
+      let fp_args = Vec.empty () in
+      
+      List.iter (fun x -> match x.ty with
+      | T_float | T_double -> Vec.push fp_args (slot_v x)
+      | _ -> Vec.push int_args (slot_v x)) args;
+      
+      Vec.push body (Inst.Call {
+        rd = r; fn = { name = fn; stamp = 0 };
+        args = Vec.to_list int_args;
+        fargs = Vec.to_list fp_args
+      })
+
+  | Load { rd; rs; offset; byte; } ->
+      let mem_slot: Slots.mem_slot = { rd = slot_v rd; base = slot_v rs; offset } in
+      Vec.push body (match byte with
+      | 1 -> Inst.Lb mem_slot
+      | 2 -> Inst.Lh mem_slot
+      | 4 -> Inst.Lw mem_slot
+      | 8 -> Inst.Ld mem_slot
+      | _ -> die ())
+
+  | Store { rd; rs; offset; byte; } ->
+      let mem_slot: Slots.mem_slot = { rd = slot_v rd; base = slot_v rs; offset } in
+      Vec.push body (match byte with
+      | 1 -> Inst.Sb mem_slot
+      | 2 -> Inst.Sh mem_slot
+      | 4 -> Inst.Sw mem_slot
+      | 8 -> Inst.Sd mem_slot
+      | _ -> die ())
+
+  | AssignInt { rd; imm } ->
+      Vec.push body (Inst.Li { rd = slot_v rd; imm = IntImm imm })
+
+  | AssignInt64 { rd; imm } ->
+      Vec.push body (Inst.Li { rd = slot_v rd; imm = Int64Imm imm })
+
+  | Assign { rd; rs } ->
+      Vec.push body (Inst.Mv { rd = slot_v rd; rs = slot_v rs })
+
+  | Phi phi ->
+      Vec.push (Hashtbl.find phis name) phi
+
+  | Return ret ->
+      terminator := Term.Ret (slot_v ret)
+
+  | Branch { cond; ifso; ifnot } ->
+      terminator := Term.Beq {
+        rs1 = slot_v cond; rs2 = Slot.Reg Zero;
+        ifso = { name = ifso; stamp = 0 };
+        ifnot = { name = ifnot; stamp = 0 } }
+
+  | Jump label ->
+      terminator := Term.J { name = label; stamp = 0 }
+    
+  | _ -> die()
+
+let gen_fn (f: fn) =
+  let int_args = Vec.empty () in
+  let fp_args = Vec.empty () in
+  
+  (* Split arguments into integral and FP *)
+  List.iter (fun x -> match x.ty with
+  | T_float | T_double -> Vec.push fp_args (slot_v x)
+  | _ -> Vec.push int_args (slot_v x)) f.args;
+
+  Vec.push vfuncs {
+    funn = { name = f.fn; stamp = 0 };
+    args = Vec.to_list int_args;
+    fargs = Vec.to_list fp_args;
+    entry = { name = f.fn; stamp = 0 }
+  };
+
+  let blocks = get_blocks f.fn in
+  List.iter (fun x ->
+    let block = block_of x in
+    let body = Vec.empty () in
+    let term = ref (Term.Ret Unit) in
+    Vec.iter (convert_single x body term) block.body;
+    Vec.push vblocks {
+      body; term = !term; preds =
+        Vec.to_list block.pred
+        |> List.map (fun x -> VBlock.NormalEdge { name = x; stamp = 0 })
+    }
+  ) blocks;
+  ()
+
+let gen_var v = ()
+
+let gen_extarr arr = ()
+
+(** On calling this function, `ssa` must be coherent with basic block information in `opt` *)
+let virtasm_of_ssa (ssa : Riscv_ssa.t list) =
+  List.iter (fun x -> match x with
+  | FnDecl f -> gen_fn f
+  | GlobalVarDecl var -> gen_var var
+  | ExtArray arr -> gen_extarr arr
+  | _ -> failwith "riscv_virtasm_generate.ml: bad toplevel SSA") ssa;
+  ({
+    funcs = Label.Map.empty;
+    blocks = Label.Map.empty;
+    consts = Label.Map.empty;
+    loop_vars = Label.Map.empty;
+  }: VProg.t)
+


### PR DESCRIPTION
Reformed the existing virtual assembly, and added conversion to basic arithmetic and control flow instructions from SSA.

I choose not to use `Label.t` which requires stamps to guarantee uniquity, as generated labels are already unique in SSA. Therefore I changed them to normal `string`s to cooperate better with the previous part of pipeline.
