### PR TITLE
Bugfix for register spilling

### DIFF
--- a/src/label.ml
+++ b/src/label.ml
@@ -19,66 +19,28 @@ module Label = struct
     }
 
   include struct
-    let _ = fun (_ : t) -> ()
+    let sexp_of_t { name; stamp } =
+      S.List [
+        S.List [ S.Atom "name"; Moon_sexp_conv.sexp_of_string name ];
+        S.List [ S.Atom "stamp"; Moon_sexp_conv.sexp_of_int stamp ]]
 
-    let sexp_of_t =
-      (fun { name = name__002_; stamp = stamp__004_ } ->
-         let bnds__001_ = ([] : _ Stdlib.List.t) in
-         let bnds__001_ =
-           let arg__005_ = Moon_sexp_conv.sexp_of_int stamp__004_ in
-           (S.List [ S.Atom "stamp"; arg__005_ ] :: bnds__001_ : _ Stdlib.List.t)
-         in
-         let bnds__001_ =
-           let arg__003_ = Moon_sexp_conv.sexp_of_string name__002_ in
-           (S.List [ S.Atom "name"; arg__003_ ] :: bnds__001_ : _ Stdlib.List.t)
-         in
-         S.List bnds__001_
-       : t -> S.t)
-    ;;
+    let equal a b =
+         if a == b then true
+         else a.name = b.name && a.stamp = b.stamp
 
-    let _ = sexp_of_t
+    let hash_fold_t hsv arg =
+      let hsv = 
+       Ppx_base.hash_fold_string hsv arg.name
+      in Ppx_base.hash_fold_int hsv arg.stamp
 
-    let equal =
-      (fun a__006_ b__007_ ->
-         if Stdlib.( == ) a__006_ b__007_
-         then true
-         else Stdlib.( = ) (a__006_.stamp : int) b__007_.stamp
-       : t -> t -> bool)
-    ;;
+    let hash arg =
+      Ppx_base.get_hash_value (hash_fold_t (Ppx_base.create ()) arg)
 
-    let _ = equal
-
-    let (hash_fold_t : Ppx_base.state -> t -> Ppx_base.state) =
-      fun hsv arg ->
-      let hsv =
-        let hsv = hsv in
-        hsv
-      in
-      Ppx_base.hash_fold_int hsv arg.stamp
-    ;;
-
-    let _ = hash_fold_t
-
-    let (hash : t -> Ppx_base.hash_value) =
-      let func arg =
-        Ppx_base.get_hash_value
-          (let hsv = Ppx_base.create () in
-           hash_fold_t hsv arg)
-      in
-      fun x -> func x
-    ;;
-
-    let _ = hash
-
-    let compare =
-      (fun a__008_ b__009_ ->
-         if Stdlib.( == ) a__008_ b__009_
-         then 0
-         else Stdlib.compare (a__008_.stamp : int) b__009_.stamp
-       : t -> t -> int)
-    ;;
-
-    let _ = compare
+    let compare a b =
+        if a == b then 0
+        else if a.name <> b.name then
+          Stdlib.compare a.name b.name
+        else Stdlib.compare a.stamp b.stamp
   end
 end
 

--- a/src/riscv_generate.ml
+++ b/src/riscv_generate.ml
@@ -868,9 +868,9 @@ let rec do_convert tac (expr: Mcore.expr) =
       let old_vars = !loop_vars in
 
       (* Get the labels *)
-      let loop = Printf.sprintf "%s_%d" label.name label.stamp in
-      let before = Printf.sprintf "before_%s" loop in
-      let exit = Printf.sprintf "exit_%s" loop in
+      let loop = Printf.sprintf "loophead_%s_%d" label.name label.stamp in
+      let before = Printf.sprintf "loopbefore_%s" loop in
+      let exit = Printf.sprintf "loopexit_%s" loop in
       
       Vec.push tac (Jump before);
       
@@ -910,7 +910,7 @@ let rec do_convert tac (expr: Mcore.expr) =
       List.iter2 (fun rd rs -> Vec.push tac (Assign { rd; rs })) !loop_vars results;
 
       (* Jump back to the beginning of the loop. *)
-      let loop_name = Printf.sprintf "%s_%d" label.name label.stamp in 
+      let loop_name = Printf.sprintf "loophead_%s_%d" label.name label.stamp in 
       Vec.push tac (Jump loop_name);
       unit
 

--- a/src/riscv_opt.ml
+++ b/src/riscv_opt.ml
@@ -31,7 +31,10 @@ let exit_fn = Hashtbl.create 256
 let (params: (string, var list) Hashtbl.t) = Hashtbl.create 256
 
 (** Get the basic block with label `name`. *)
-let block_of name = Hashtbl.find basic_blocks name
+let block_of name =
+  match Hashtbl.find_opt basic_blocks name with
+  | None -> failwith (Printf.sprintf "riscv_opt.ml: unknown basic block: %s" name)
+  | Some x -> x
 
 (** Get the body of a basic block. *)
 let body_of name = (block_of name).body |> Vec.to_list

--- a/src/riscv_reg.ml
+++ b/src/riscv_reg.ml
@@ -176,6 +176,7 @@ module Imm = struct
   let to_string imm =
     match imm with
     | IntImm i -> string_of_int i
+    | Int64Imm i -> Int64.to_string i
     | FloatImm f -> string_of_float f
   ;;
 end

--- a/src/riscv_reg_util.ml
+++ b/src/riscv_reg_util.ml
@@ -57,7 +57,8 @@ module RPO = struct
   let get_func_rpo (funn : VFuncLabel.t) (rpo : t) : VBlockLabel.t list =
     match VFuncMap.find_opt rpo funn with
     | Some x -> x
-    | None -> failwith "RPO.get_func_rpo: function not found"
+    | None -> failwith
+      (Printf.sprintf "riscv_reg_util.ml: RPO not found for label %s_%d" funn.name funn.stamp)
   ;;
 
   let empty : t = VFuncMap.empty

--- a/test.py
+++ b/test.py
@@ -68,7 +68,13 @@ with DirContext("test"):
      
     for src in cases:
         print(f"Execute task: {src}")
-
+        
+        # Remove files from last time
+        try_remove(f"build/{target}.s.ir")
+        try_remove(f"build/{target}.s.ssa")
+        try_remove(f"build/{target}.s-no-opt.ssa")
+        try_remove(f"build/{target}.s.vasm")
+        
         # Note build-package is ignorant of target. It builds to a common IR.
         os.system(f"moonc build-package src/{src}/{src}.mbt -is-main -std-path {bundled} -o build/{src}.core")
 


### PR DESCRIPTION
Bugfixes:

1) `Label.t` used to only compare stamps, ignoring label names. Now it takes both into account.
2) In `riscv_reg_spill.ml`, the global variable `rpo` is now properly initialized.
3) `Vec.make ~dummy len` actually makes a zero-length vector, which is counterintuitive. To avoid disturbing existing code, I replaced their calls in `riscv_reg_spill.ml` with `Vec.of_list (List.init ...)`. 