### PR TITLE
Implementation for more SSA conversions and Virtasm instructions.

### DIFF
--- a/src/riscv_generate.ml
+++ b/src/riscv_generate.ml
@@ -524,7 +524,25 @@ let deal_with_prim tac rd (prim: Primitive.prim) args =
   
   | Pprintln ->
       Vec.push tac (CallExtern { rd; fn = "puts"; args })
-  
+  | Pnot -> 
+      Vec.push tac (Not { rd; rs1 = List.hd args })
+  (* | Primitive.Pccall { func_name = "";_} -> _
+  | Primitive.Pnot -> _
+  | Primitive.Praise -> _
+  | Primitive.Punreachable -> _
+  | Primitive.Pcatch -> _
+  | Primitive.Psequand -> _
+  | Primitive.Psequor -> _
+  | Primitive.Pstringequal -> _
+  | Primitive.Pclosure_to_extern_ref -> _
+  | Primitive.Pnull_string_extern -> _
+  | Primitive.Perror_to_string -> _
+  | Primitive.Pany_to_string -> _
+  | Primitive.Pintrinsic -> _
+  | Primitive.Pcast -> _
+  | Primitive.Pcompare -> _
+  | Primitive.Pset_enum_field -> _
+  | Primitive.Pmake_value_or_error *)
   | _ -> failwith (Printf.sprintf "unknown primitive %s" (Primitive.sexp_of_prim prim |> S.to_string))
 
 

--- a/src/riscv_generate.ml
+++ b/src/riscv_generate.ml
@@ -154,7 +154,7 @@ let deal_with_prim tac rd (prim: Primitive.prim) args =
             (* Discard higher bits by shifting, but arithmetic *)
             let temp = new_temp Mtype.T_uint64 in
             Vec.push tac (Slli { rd = temp; rs = arg; imm = 32 });
-            Vec.push tac (Srai { rd; rs = temp; imm = 32 })
+            Vec.push tac (Srli { rd; rs = temp; imm = 32 })
 
         | I32, U32 | U32, I32 | I32, I64 ->
             (* Simply do nothing *)
@@ -527,7 +527,6 @@ let deal_with_prim tac rd (prim: Primitive.prim) args =
   | Pnot -> 
       Vec.push tac (Not { rd; rs1 = List.hd args })
   (* | Primitive.Pccall { func_name = "";_} -> _
-  | Primitive.Pnot -> _
   | Primitive.Praise -> _
   | Primitive.Punreachable -> _
   | Primitive.Pcatch -> _

--- a/src/riscv_generate.ml
+++ b/src/riscv_generate.ml
@@ -932,6 +932,12 @@ let rec do_convert tac (expr: Mcore.expr) =
       Vec.push tac (Jump loop_name);
       unit
 
+  | Cexpr_break { label; _ } ->
+    (* Jumps to exit of the loop. *)
+    let loop_name = Printf.sprintf "loophead_%s_%d" label.name label.stamp in
+    Vec.push tac (Jump ("loopexit_" ^ loop_name));
+    unit
+
   (* Assigns mutable variables. *)
   | Cexpr_assign { var; expr; ty } ->
       let rd = do_convert tac expr in
@@ -977,12 +983,6 @@ let rec do_convert tac (expr: Mcore.expr) =
 
       List.iter visit fields;
       rd
-
-  | Cexpr_break { label; _ } ->
-      (* Jumps to exit of the loop. *)
-      let loop_name = Printf.sprintf "%s_%d" label.name label.stamp in
-      Vec.push tac (Jump ("exit_" ^ loop_name));
-      unit
 
   | Cexpr_tuple { exprs; ty; _ } ->
       let rd = new_temp ty in

--- a/src/riscv_virtasm.ml
+++ b/src/riscv_virtasm.ml
@@ -210,6 +210,8 @@ module Inst = struct
     | Sltw of r_slot
     | Sltu of r_slot
     | Sltuw of r_slot
+    | Slti of i_slot
+    | Sltiw of i_slot
 
     | Sll of r_slot (* shift left logical *)
     | Sllw of r_slot
@@ -222,12 +224,12 @@ module Inst = struct
 
     | Slli of i_slot (* shift left logical immediate *)
     | Slliw of i_slot
+
     | Srli of i_slot (* shift right logical immediate *)
     | Srliw of i_slot
+    
     | Srai of i_slot (* shift right arithmetic immediate *)
     | Sraiw of i_slot
-    | Slti of i_slot
-    | Sltiw of i_slot
     (* Multiplication and Division Instructions *)
     (* Memory Access Instructions *)
     | Lb of mem_slot

--- a/src/riscv_virtasm_generate.ml
+++ b/src/riscv_virtasm_generate.ml
@@ -232,6 +232,9 @@ let convert_single name body terminator (inst: Riscv_ssa.t) =
       Vec.push body (Inst.Xor { rd = slot_v rd; rs1 = slot_v rs1; rs2 = slot_v rs2 });
       Vec.push body (Inst.Sltu { rd = slot_v rd; rs1 = Slot.Reg Zero; rs2 = slot_v rd })
 
+  | Not { rd; rs1 } -> 
+      Vec.push body (Inst.Slti { rd = slot_v rd; rs1 = slot_v rs1; imm = 1 })
+
   | Call { rd; fn; args } ->
       let r = slot_v rd in
       let int_args = Vec.empty () in
@@ -332,6 +335,26 @@ let convert_single name body terminator (inst: Riscv_ssa.t) =
 
   | Jump label ->
       terminator := Term.J (label_of label)
+  (* | Neg -> _
+  | Sll -> _
+  | Slli -> _
+  | Slti -> _
+  | FAdd -> _
+  | FSub -> _
+  | FMul -> _
+  | FDiv -> _
+  | FLess -> _
+  | FLeq -> _
+  | FGreat -> _
+  | FGeq -> _
+  | FEq -> _
+  | FNeq -> _
+  | FNeg -> _
+  | AssignFP -> _
+  | JumpIndirect -> _
+  | FnDecl -> _
+  | GlobalVarDecl -> _
+  | ExtArray _ -> _ *)
     
   | _ -> failwith (Printf.sprintf "unsupported ssa: %s" (to_string inst))
 


### PR DESCRIPTION
Main contributions:

- SSA Pnot conversion to virtasm [Check](6ebb65b9ed16a9815ff90779214850cd1e29c612)
- Virtasm SLI, SLLI, SRLI, SLTI [Check](521fd10c4847f1d9acf3eb63cb983d14fb28617c)

Bug fixes:

- Break statement in loops will generate correct label names now [Check](16cf2a21d0f3d059ddaa13dcb2e698958f450277)
- Choose correct virtasm instructions for "i64->i32" "u64->i32" now [Check](688344ac9001455e5fdfd25524aa8d49ed3c9bae)

Now following tests have passed:

- basic
- closure01
- closure03
- match03
- fib
- random
- control
- topexpr
- mergesort